### PR TITLE
Removed bootstrap-servers from xml

### DIFF
--- a/src/main/java/com/gznznzjsn/orderservice/web/kafka/TaskProducerConfig.java
+++ b/src/main/java/com/gznznzjsn/orderservice/web/kafka/TaskProducerConfig.java
@@ -32,8 +32,6 @@ public class TaskProducerConfig {
     public SenderOptions<String, String> senderOptions() {
         XMLParser parser = new XMLParser(taskProducerSettings);
         Map<String, Object> properties = new HashMap<>();
-        properties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                parser.parse("bootstrapServers"));
         properties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
                 parser.parse("keySerializerClass"));
         properties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,

--- a/src/main/resources/kafka/taskProducer.xml
+++ b/src/main/resources/kafka/taskProducer.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <taskProducer>
-    <bootstrapServers>kafka-service:9092</bootstrapServers>
     <keySerializerClass>org.apache.kafka.common.serialization.StringSerializer</keySerializerClass>
     <valueSerializerClass>org.apache.kafka.common.serialization.StringSerializer</valueSerializerClass>
 </taskProducer>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the Kafka producer configuration for the order service. 

### Detailed summary
- Removed `bootstrapServers` property from `taskProducer.xml`
- Added `TaskProducerConfig.java` to configure Kafka producer properties
- `TaskProducerConfig.java` now parses properties from `taskProducer.xml`
- `bootstrapServers`, `keySerializerClass`, and `valueSerializerClass` properties are now configured in `TaskProducerConfig.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->